### PR TITLE
Add VideoPlayer React component

### DIFF
--- a/docs/components/examples/DemoVideo.tsx
+++ b/docs/components/examples/DemoVideo.tsx
@@ -1,0 +1,48 @@
+import { VideoPlayer } from '@livepeer/react';
+import { Asset } from 'livepeer';
+import { AssetIdOrString } from 'livepeer/src/types/provider';
+import { useState } from 'react';
+
+// const assetId: AssetIdOrString = '01c94ad7-35f1-4a55-9802-57c2fa39b964'; // clock
+const assetId: AssetIdOrString = 'a4e87108-d3b5-4e6b-bb9c-7ca321119cb6'; // waterfall
+
+// TODO: do not merge in production
+export const DemoVideo = () => {
+  const [playbackUrl, setPlaybackUrl] = useState<string | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
+
+  const handleAsset = (asset: Asset) => setPlaybackUrl(asset.playbackUrl);
+  const handleError = (error: Error) => setErrorMessage(error.message);
+
+  return (
+    <>
+      <VideoPlayer
+        assetId={assetId}
+        receivedAsset={handleAsset}
+        receivedError={handleError}
+        width="640"
+        loop
+        muted
+      />
+
+      <p>
+        AssetId: {assetId}
+        <br />
+        {errorMessage && (
+          <>
+            Error: {errorMessage}
+            <br />
+          </>
+        )}
+        {playbackUrl && (
+          <>
+            Playback url: {playbackUrl}
+            <br />
+          </>
+        )}
+      </p>
+    </>
+  );
+};

--- a/docs/components/examples/index.ts
+++ b/docs/components/examples/index.ts
@@ -1,2 +1,3 @@
 export { Asset } from './Asset';
 export { Stream } from './Stream';
+export { DemoVideo } from './DemoVideo';

--- a/docs/pages/examples/meta.en-US.json
+++ b/docs/pages/examples/meta.en-US.json
@@ -1,4 +1,5 @@
 {
   "view-asset": "Create & Watch a VOD",
-  "view-stream": "Create & Watch a Stream"
+  "view-stream": "Create & Watch a Stream",
+  "video-player": "Video Player Example"
 }

--- a/docs/pages/examples/video-player.en-US.mdx
+++ b/docs/pages/examples/video-player.en-US.mdx
@@ -3,8 +3,11 @@ title: 'Video Player Example'
 description: 'TODO: do not merge in production. It is just for metrics reporting testing purposes'
 ---
 
+import { DemoVideo } from '@components/examples';
+
 # Video Player Example
 
 <hr />
+<DemoVideo />
 
 This player is reporting metrics to `wss://patchy.ddvtech.com/mist/json_bunny.js`.

--- a/docs/pages/examples/video-player.en-US.mdx
+++ b/docs/pages/examples/video-player.en-US.mdx
@@ -10,4 +10,4 @@ import { DemoVideo } from '@components/examples';
 <hr />
 <DemoVideo />
 
-This player is reporting metrics to `wss://patchy.ddvtech.com/mist/json_bunny.js`.
+This player is reporting metrics to `wss://sao-canary-catalyst-0.livepeer.fun`.

--- a/docs/pages/examples/video-player.en-US.mdx
+++ b/docs/pages/examples/video-player.en-US.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Video Player Example'
+description: 'TODO: do not merge in production. It is just for metrics reporting testing purposes'
+---
+
+# Video Player Example
+
+<hr />
+
+This player is reporting metrics to `wss://patchy.ddvtech.com/mist/json_bunny.js`.

--- a/examples/_dev/src/components/AssetDemoPlayer.tsx
+++ b/examples/_dev/src/components/AssetDemoPlayer.tsx
@@ -1,0 +1,47 @@
+import { VideoPlayer } from '@livepeer/react';
+import { Asset } from 'livepeer';
+import { AssetIdOrString } from 'livepeer/src/types/provider';
+import { useState } from 'react';
+
+const assetId: AssetIdOrString = '01c94ad7-35f1-4a55-9802-57c2fa39b964'; // clock
+// const assetId: AssetIdOrString = 'a4e87108-d3b5-4e6b-bb9c-7ca321119cb6'; // waterfall
+
+export const AssetDemoPlayer = () => {
+  const [playbackUrl, setPlaybackUrl] = useState<string | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
+
+  const handleAsset = (asset: Asset) => setPlaybackUrl(asset.playbackUrl);
+  const handleError = (error: Error) => setErrorMessage(error.message);
+
+  return (
+    <>
+      <VideoPlayer
+        assetId={assetId}
+        receivedAsset={handleAsset}
+        receivedError={handleError}
+        width="640"
+        loop
+        muted
+      />
+
+      <p>
+        AssetId: {assetId}
+        <br />
+        {errorMessage && (
+          <>
+            Error: {errorMessage}
+            <br />
+          </>
+        )}
+        {playbackUrl && (
+          <>
+            Playback url: {playbackUrl}
+            <br />
+          </>
+        )}
+      </p>
+    </>
+  );
+};

--- a/examples/_dev/src/components/index.ts
+++ b/examples/_dev/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Asset } from './Asset';
 export { Connect } from './Connect';
 export { Stream } from './Stream';
+export { AssetDemoPlayer } from './AssetDemoPlayer';

--- a/examples/_dev/src/pages/demoPlayer.tsx
+++ b/examples/_dev/src/pages/demoPlayer.tsx
@@ -1,0 +1,14 @@
+import { AssetDemoPlayer } from '../components';
+
+const Page = () => {
+  return (
+    <>
+      <h1>Demo Video Player</h1>
+
+      <h2>VOD Asset playback</h2>
+      <AssetDemoPlayer />
+    </>
+  );
+};
+
+export default Page;

--- a/examples/_dev/src/pages/index.tsx
+++ b/examples/_dev/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import Link from 'next/link';
 
 import { Asset, Connect, Stream } from '../components';
 
@@ -10,6 +10,10 @@ const Page = () => {
       <Stream />
       <hr />
       <Asset />
+      <hr />
+      <Link href="/demoPlayer">
+        <a>Demo Video Player</a>
+      </Link>
     </>
   );
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,6 +38,7 @@
     "@tanstack/query-sync-storage-persister": "4.0.10",
     "@tanstack/react-query": "4.1.3",
     "@tanstack/react-query-persist-client": "4.0.10",
+    "hls.js": "^1.2.1",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/react/src/components/HlsVideoPlayer.tsx
+++ b/packages/react/src/components/HlsVideoPlayer.tsx
@@ -1,7 +1,10 @@
 import Hls, { ErrorTypes, Events, HlsConfig } from 'hls.js';
 import React, { RefObject, VideoHTMLAttributes, useEffect } from 'react';
 
-import { reportVideoMetrics } from '../utils/videoMetrics';
+import {
+  createMetricsReportingUrl,
+  reportVideoMetrics,
+} from '../utils/videoMetrics';
 
 export interface GenericHlsVideoPlayerProps
   extends VideoHTMLAttributes<HTMLVideoElement> {
@@ -55,15 +58,10 @@ export function HlsVideoPlayer({
           }
         });
 
-        // TODO: re-enable after testing and before merging
-        // const metricReportingUrl = createMetricsReportingUrl(src);
-        // if (metricReportingUrl) {
-        //   reportVideoMetrics(playerRef.current, metricReportingUrl);
-        // }
-        reportVideoMetrics(
-          playerRef.current,
-          'wss://patchy.ddvtech.com/mist/json_bunny.js',
-        );
+        const metricReportingUrl = createMetricsReportingUrl(src);
+        if (metricReportingUrl) {
+          reportVideoMetrics(playerRef.current, metricReportingUrl);
+        }
       });
 
       newHls.on(Events.ERROR, function (_event, data) {

--- a/packages/react/src/components/HlsVideoPlayer.tsx
+++ b/packages/react/src/components/HlsVideoPlayer.tsx
@@ -1,10 +1,5 @@
 import Hls, { ErrorTypes, Events, HlsConfig } from 'hls.js';
-import React, {
-  RefObject,
-  VideoHTMLAttributes,
-  createRef,
-  useEffect,
-} from 'react';
+import React, { RefObject, VideoHTMLAttributes, useEffect } from 'react';
 
 import { reportVideoMetrics } from '../utils/videoMetrics';
 
@@ -23,7 +18,7 @@ export interface HlsVideoPlayerProps extends GenericHlsVideoPlayerProps {
 
 export function HlsVideoPlayer({
   hlsConfig,
-  playerRef = createRef<HTMLVideoElement>(),
+  playerRef = React.createRef<HTMLVideoElement>(),
   src,
   autoPlay = true,
   controls = true,

--- a/packages/react/src/components/HlsVideoPlayer.tsx
+++ b/packages/react/src/components/HlsVideoPlayer.tsx
@@ -1,0 +1,122 @@
+import Hls, { ErrorTypes, Events, HlsConfig } from 'hls.js';
+import React, {
+  RefObject,
+  VideoHTMLAttributes,
+  createRef,
+  useEffect,
+} from 'react';
+
+import { reportVideoMetrics } from '../utils/videoMetrics';
+
+export interface GenericHlsVideoPlayerProps
+  extends VideoHTMLAttributes<HTMLVideoElement> {
+  hlsConfig?: HlsConfig;
+  playerRef?: RefObject<HTMLVideoElement>;
+  autoPlay?: boolean;
+  controls?: boolean;
+  width?: string | number;
+}
+
+export interface HlsVideoPlayerProps extends GenericHlsVideoPlayerProps {
+  src: string;
+}
+
+export function HlsVideoPlayer({
+  hlsConfig,
+  playerRef = createRef<HTMLVideoElement>(),
+  src,
+  autoPlay = true,
+  controls = true,
+  width = '100%',
+  ...props
+}: HlsVideoPlayerProps) {
+  useEffect(() => {
+    let hls: Hls;
+
+    function _initPlayer() {
+      hls?.destroy();
+
+      const newHls = new Hls({
+        enableWorker: false,
+        ...hlsConfig,
+      });
+
+      if (playerRef.current !== null) {
+        newHls.attachMedia(playerRef.current);
+      }
+
+      newHls.on(Events.MEDIA_ATTACHED, () => {
+        newHls.loadSource(src);
+
+        newHls.on(Events.MANIFEST_PARSED, () => {
+          if (autoPlay) {
+            playerRef?.current
+              ?.play()
+              .catch(() =>
+                console.log(
+                  'Unable to autoplay prior to user interaction with the dom.',
+                ),
+              );
+          }
+        });
+
+        // TODO: re-enable after testing and before merging
+        // const metricReportingUrl = createMetricsReportingUrl(src);
+        // if (metricReportingUrl) {
+        //   reportVideoMetrics(playerRef.current, metricReportingUrl);
+        // }
+        reportVideoMetrics(
+          playerRef.current,
+          'wss://patchy.ddvtech.com/mist/json_bunny.js',
+        );
+      });
+
+      newHls.on(Events.ERROR, function (_event, data) {
+        if (data.fatal) {
+          switch (data.type) {
+            case ErrorTypes.NETWORK_ERROR:
+              newHls.startLoad();
+              break;
+            case ErrorTypes.MEDIA_ERROR:
+              newHls.recoverMediaError();
+              break;
+            default:
+              _initPlayer();
+              break;
+          }
+        }
+      });
+
+      hls = newHls;
+    }
+
+    if (typeof window !== 'undefined') {
+      // Check for Media Source support
+      if (Hls.isSupported()) {
+        _initPlayer();
+      }
+    }
+
+    return () => {
+      hls?.destroy();
+    };
+  }, [autoPlay, hlsConfig, playerRef, src]);
+
+  // If Media Source is supported, use HLS.js to play video
+  if (typeof window !== 'undefined' && Hls.isSupported())
+    return (
+      <video ref={playerRef} controls={controls} width={width} {...props} />
+    );
+
+  // Fallback to using a regular video player if HLS is supported by default in the user's browser
+  return (
+    <video
+      ref={playerRef}
+      src={src}
+      autoPlay={autoPlay}
+      controls={controls}
+      width={width}
+      {...props}
+    />
+  );
+}

--- a/packages/react/src/components/VideoPlayer.tsx
+++ b/packages/react/src/components/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import { Asset, AssetIdOrString } from 'livepeer/src/types/provider';
-import React, { createRef, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useAsset } from '../hooks';
 import { GenericHlsVideoPlayerProps, HlsVideoPlayer } from './HlsVideoPlayer';
@@ -12,7 +12,7 @@ export interface VideoPlayerProps extends GenericHlsVideoPlayerProps {
 
 export function VideoPlayer({
   hlsConfig,
-  playerRef = createRef<HTMLVideoElement>(),
+  playerRef = React.createRef<HTMLVideoElement>(),
   assetId,
   receivedAsset,
   receivedError,

--- a/packages/react/src/components/VideoPlayer.tsx
+++ b/packages/react/src/components/VideoPlayer.tsx
@@ -1,0 +1,52 @@
+import { Asset, AssetIdOrString } from 'livepeer/src/types/provider';
+import React, { createRef, useEffect, useState } from 'react';
+
+import { useAsset } from '../hooks';
+import { GenericHlsVideoPlayerProps, HlsVideoPlayer } from './HlsVideoPlayer';
+
+export interface VideoPlayerProps extends GenericHlsVideoPlayerProps {
+  assetId: AssetIdOrString;
+  receivedAsset?: (asset: Asset) => void;
+  receivedError?: (error: Error) => void;
+}
+
+export function VideoPlayer({
+  hlsConfig,
+  playerRef = createRef<HTMLVideoElement>(),
+  assetId,
+  receivedAsset,
+  receivedError,
+  autoPlay = true,
+  controls = true,
+  width = '100%',
+  ...props
+}: VideoPlayerProps) {
+  const { data: asset, error } = useAsset(assetId);
+  const [playbackUrl, setPlaybackUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!asset) return;
+    setPlaybackUrl(asset.playbackUrl);
+    receivedAsset && receivedAsset(asset);
+  }, [asset]);
+
+  useEffect(() => {
+    if (!error) return;
+    console.error(error);
+    receivedError && receivedError(error);
+  }, [error]);
+
+  if (!playbackUrl) return <></>;
+
+  return (
+    <HlsVideoPlayer
+      hlsConfig={hlsConfig}
+      playerRef={playerRef}
+      src={playbackUrl}
+      autoPlay={autoPlay}
+      controls={controls}
+      width={width}
+      {...props}
+    />
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,0 +1,1 @@
+export { VideoPlayer } from './VideoPlayer';

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -9,6 +9,7 @@ it('should expose correct exports', () => {
       "Context",
       "LivepeerConfig",
       "useClient",
+      "VideoPlayer",
       "useAsset",
       "useBondingManager",
       "useController",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@ export { createReactClient } from './client';
 export type { CreateReactClientConfig } from './client';
 export { Context, LivepeerConfig, useClient } from './context';
 export type { LivepeerConfigProps } from './context';
+export { VideoPlayer } from './components';
 export {
   useAsset,
   useBondingManager,

--- a/packages/react/src/utils/videoMetrics/index.ts
+++ b/packages/react/src/utils/videoMetrics/index.ts
@@ -1,0 +1,2 @@
+export { createMetricsReportingUrl } from './utils';
+export { reportVideoMetrics } from './videoMetricsReporting';

--- a/packages/react/src/utils/videoMetrics/utils.ts
+++ b/packages/react/src/utils/videoMetrics/utils.ts
@@ -1,0 +1,15 @@
+// Temporarily hardcoded catalyst node
+const METRICS_REPORTING_BASE_URL = 'wss://sao-canary-catalyst-0.livepeer.fun';
+
+function videoNameFromPlaybackUrl(url: string): string | undefined {
+  const filename: string[] = url.split('/');
+  const videoName = filename[filename.length - 2];
+  return videoName ? videoName.split('.')[0] : undefined;
+}
+
+export function createMetricsReportingUrl(src: string): string | undefined {
+  const videoName = videoNameFromPlaybackUrl(src);
+  return videoName
+    ? `${METRICS_REPORTING_BASE_URL}/json_${videoName}.js`
+    : undefined;
+}

--- a/packages/react/src/utils/videoMetrics/videoMetricsReporting.js
+++ b/packages/react/src/utils/videoMetrics/videoMetricsReporting.js
@@ -1,0 +1,367 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-redeclare */
+
+/**
+ * Gather playback metrics from a generic html5 video (or audio) element and report those back to an arbitrary websocket using the same format the MistServer Meta-player uses.
+ * @param video                 Element to capture playback metrics from
+ * @param reportingWebsocketUrl Url to the websocket to report to
+ */
+export function reportVideoMetrics(video, reportingWebsocketUrl) {
+  // console.log("reportGenericVideoMetrics: ", reportingWebsocketUrl)
+  if (
+    video._reportGenericVideoMetrics &&
+    video._reportGenericVideoMetrics == reportingWebsocketUrl
+  ) {
+    // console.log("video._reportGenericVideoMetrics && (video._reportGenericVideoMetrics == reportingWebsocketUrl");
+    return; //do not attach twice (to the same websocket)
+  }
+  if (!window.WebSocket) {
+    console.log('no support to report in this browser');
+    return;
+  } //no support to report in this browser
+  if (!('play' in video) || !('currentTime' in video)) {
+    console.log('lazy check if this is a video or audio element');
+    return;
+  } //lazy check if this is a video or audio element
+
+  video._reportGenericVideoMetrics = reportingWebsocketUrl;
+  var ws;
+  function connect(n) {
+    ws = new WebSocket(reportingWebsocketUrl);
+    ws.n = n ? n : 0;
+
+    //ws.onmessage : there's no need to listen to messages from the server
+    ws.onopen = function () {
+      //enable active statistics reporting
+      if (timeOut === null) {
+        timeOut = true;
+        report();
+      }
+      this.wasConnected = true;
+      this.n = 0;
+    };
+    ws.onclose = function () {
+      //disable active statistics gathering
+      if (timeOut) {
+        clearTimeout(timeOut);
+      }
+      timeOut = null;
+
+      //autoreconnect if connection is broken
+      if (ws.wasConnected) {
+        setTimeout(function () {
+          connect(ws.n++);
+        }, Math.pow(2, ws.n) * 1e3); //if the connection keeps failing, wait longer before retrying
+      }
+    };
+    // console.log("ws: ", ws);
+    return ws;
+  }
+
+  try {
+    ws = connect();
+  } catch (e) {
+    return false;
+  }
+
+  var timeOut = null;
+
+  function send(obj) {
+    if (ws.readyState != ws.OPEN) {
+      return;
+    }
+    ws.send(JSON.stringify(obj));
+  }
+
+  var stats = {
+    //save playback metrics here
+    d: {
+      //this contains the most recent data, any changes are immediately applied here
+      nWaiting: 0,
+      timeWaiting: 0,
+      nStalled: 0,
+      timeStalled: 0,
+      timeUnpaused: 0,
+      nError: 0,
+      videoHeight: null,
+      videoWidth: null,
+      playerHeight: null,
+      playerWidth: null,
+      player: 'generic',
+      pageUrl: location.href,
+      sourceUrl: video.currentSrc,
+    },
+    last: {
+      //this contains the metrics storage object that was sent last
+      firstPlayback: null,
+      nWaiting: 0,
+      timeWaiting: 0,
+      nStalled: 0,
+      timeStalled: 0,
+      timeUnpaused: 0,
+      nError: 0,
+      lastError: null,
+      playbackScore: 1,
+      autoplay: null,
+      videoHeight: null,
+      videoWidth: null,
+      playerHeight: null,
+      playerWidth: null,
+    },
+  };
+
+  /////////////////////
+  //  basics         //
+  /////////////////////
+
+  var firstplay = function () {
+    stats.d['firstPlayback'] =
+      new Date().getTime() - reportGenericVideoMetrics_bootMs;
+    video.removeEventListener('playing', firstplay);
+  };
+  video.addEventListener('playing', firstplay);
+
+  video.addEventListener('waiting', function () {
+    stats.d['nWaiting']++;
+  });
+  video.addEventListener('stalled', function () {
+    stats.d['nStalled']++;
+  });
+  video.addEventListener('error', function (e) {
+    stats.d['nError']++;
+    stats.d['lastError'] = video.error ? video.error.message : 'unknown';
+  });
+
+  /////////////////////
+  //  playbackScore  //
+  /////////////////////
+
+  var monitor = {
+    active: false,
+    vars: {},
+    averagingSteps: 20,
+    init: function () {
+      if (this.active) {
+        return;
+      } //it's already running, don't bother
+
+      this.vars = {
+        values: [],
+        score: false,
+      };
+      this.active = true;
+    },
+    reset: function () {
+      if (!this.active) {
+        //it's not running, start it up
+        this.init();
+        return;
+      }
+
+      this.vars.values = [];
+    },
+    destroy: function () {
+      if (!this.active) {
+        return;
+      } //it's not running, don't bother
+
+      delete this.vars;
+      this.active = false;
+    },
+    calcScore: function () {
+      if (!this.active) {
+        return;
+      }
+
+      var list = this.vars.values;
+      list.push(this.getValue()); //add the current value to the history
+
+      if (list.length <= 1) {
+        return false;
+      } //no history yet, can't calculate a score
+
+      var score = this.valueToScore(list[0], list[list.length - 1]); //should be 1, decreases if bad
+
+      //kick the oldest value from the array
+      if (list.length > this.averagingSteps) {
+        list.shift();
+      }
+
+      //the final score is the maximum of the averaged and the current value
+      score = Math.max(score, list[list.length - 1].score);
+
+      this.vars.score = score;
+
+      stats.d['playbackScore'] = Math.round(score * 10) / 10;
+
+      return score;
+    },
+    valueToScore: function (a, b) {
+      //calculate the moving average
+      //if this returns > 1, the video played faster than the clock
+      //if this returns < 0, the video time went backwards
+      var rate = 1;
+      if ('playbackRate' in video) {
+        rate = video.playbackRate;
+      }
+      return (b.video - a.video) / (b.clock - a.clock) / rate;
+    },
+    getValue: function () {
+      //save the current testing value and time
+      // If the video plays, this should keep a constant value. If the video is stalled, it will go up with 1sec/sec. If the video is playing faster, it will go down.
+      //      current clock time         - current playback time
+      var result = {
+        clock: new Date().getTime() * 1e-3,
+        video: video.currentTime,
+      };
+      if (this.vars.values.length) {
+        result.score = this.valueToScore(
+          this.vars.values[this.vars.values.length - 1],
+          result,
+        );
+      }
+
+      return result;
+    },
+  };
+
+  //enable
+  var events = ['loadstart', 'play', 'playing'];
+  for (var i in events) {
+    video.addEventListener(events[i], function () {
+      monitor.init();
+    });
+  }
+  //disable
+  var events = ['loadeddata', 'pause', 'abort', 'emptied', 'ended'];
+  for (var i in events) {
+    video.addEventListener(events[i], function () {
+      monitor.destroy();
+    });
+  }
+  //reset
+  var events = ['seeking', 'seeked', /*"canplay","playing",*/ 'ratechange'];
+  for (var i in events) {
+    video.addEventListener(events[i], function () {
+      monitor.reset();
+    });
+  }
+
+  ///////////////////////////////
+  // cumulative time counting  //
+  ///////////////////////////////
+
+  if (Object && Object.defineProperty) {
+    //for convenience we're defining the get of object properties here. It's not a disaster if these don't get gathered in older browsers. See https://caniuse.com/mdn-javascript_builtins_object_defineproperty
+
+    var timeWaiting = 0;
+    var waitingSince = false;
+    var timeStalled = 0;
+    var stalledSince = false;
+    var timeUnpaused = 0;
+    var unpausedSince = false;
+    var d = stats.d;
+
+    Object.defineProperty(d, 'timeWaiting', {
+      get: function () {
+        return (
+          timeWaiting + (waitingSince ? new Date().getTime() - waitingSince : 0)
+        );
+      },
+    });
+    Object.defineProperty(d, 'timeStalled', {
+      get: function () {
+        return (
+          timeStalled + (stalledSince ? new Date().getTime() - stalledSince : 0)
+        );
+      },
+    });
+    Object.defineProperty(d, 'timeUnpaused', {
+      get: function () {
+        return (
+          timeUnpaused +
+          (unpausedSince ? new Date().getTime() - unpausedSince : 0)
+        );
+      },
+    });
+    Object.defineProperty(d, 'videoHeight', {
+      get: function () {
+        return video ? video.videoHeight : null;
+      },
+    });
+    Object.defineProperty(d, 'videoWidth', {
+      get: function () {
+        return video ? video.videoWidth : null;
+      },
+    });
+    Object.defineProperty(d, 'playerHeight', {
+      get: function () {
+        return video ? video.clientHeight : null;
+      },
+    });
+    Object.defineProperty(d, 'playerWidth', {
+      get: function () {
+        return video ? video.clientWidth : null;
+      },
+    });
+
+    video.addEventListener('waiting', function () {
+      timeWaiting = d.timeWaiting; //in case we get waiting several times in a row
+      waitingSince = new Date().getTime();
+    });
+    video.addEventListener('stalled', function () {
+      timeStalled = d.timeStalled; //in case we get stalled several times in a row
+      stalledSince = new Date().getTime();
+    });
+    var events = ['playing', 'pause'];
+    for (var i in events) {
+      video.addEventListener(events[i], function () {
+        timeWaiting = d.timeWaiting;
+        timeStalled = d.timeStalled;
+        waitingSince = false;
+        stalledSince = false;
+      });
+    }
+    video.addEventListener('playing', function () {
+      timeUnpaused = d.timeUnpaused; //in case we get playing several times in a row
+      unpausedSince = new Date().getTime();
+    });
+    video.addEventListener('pause', function () {
+      timeUnpaused = d.timeUnpaused;
+      unpausedSince = false;
+    });
+  }
+
+  function report() {
+    if (timeOut === null) {
+      return;
+    }
+
+    monitor.calcScore(); //update playback score
+
+    //only send a report if stats have changed, and only send those changes
+    var havechanges = false;
+    var d = {};
+    for (var i in stats.d) {
+      if (stats.d[i] != stats.last[i]) {
+        d[i] = stats.d[i];
+        havechanges = true;
+        stats.last[i] = d[i];
+      }
+    }
+    if (havechanges) {
+      send(d);
+    }
+
+    timeOut = setTimeout(function () {
+      report();
+    }, 1e3);
+  }
+
+  return true;
+}
+
+let reportGenericVideoMetrics_bootMs = new Date().getTime(); //used for firstPlayback value
+
+/* eslint-enable @typescript-eslint/no-unused-vars */
+/* eslint-enable no-redeclare */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,7 @@ importers:
       '@types/react-dom': ^18.0.6
       '@types/use-sync-external-store': ^0.0.3
       ethers: ^5.6.9
+      hls.js: ^1.2.1
       livepeer: ^0.2.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -234,6 +235,7 @@ importers:
       '@tanstack/query-sync-storage-persister': 4.0.10
       '@tanstack/react-query': 4.1.3_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-persist-client': 4.0.10
+      hls.js: 1.2.1
       use-sync-external-store: 1.2.0_react@18.2.0
     devDependencies:
       '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
@@ -7345,6 +7347,10 @@ packages:
 
   /hls.js/1.2.0:
     resolution: {integrity: sha512-QIEQIUpBRhcpBMq3NA+/qozG8lbNfVekuX7kCMUlhiVu4382xFWsnwcuBe/CA4Gp/wB/pf2aRBaGRFlxh/FN8g==}
+    dev: false
+
+  /hls.js/1.2.1:
+    resolution: {integrity: sha512-+m/5+ikSpmQQvb6FmVWZUZfzvTJMn/QVfiCGP1Oq9WW4RKrAvxlExkhhbcVGgGqLNPFk1kdFkVQur//wKu3JVw==}
     dev: false
 
   /hmac-drbg/1.0.1:


### PR DESCRIPTION
## Description
Created a VideoPlayer component specific for Livepeer use case.

**WARNING: Not ready to be evaluated or merged yet.**

## Additional Information

- Added the VideoPlayer react component
- Added the metrics reporting
- Created example video player in the playground
- Created testing example in the Docs Examples (it needs to be removed before merging)


## Todos

- [ ] Support loading a video with a streamId or playbackId
- [ ] Decide if pulling the playbackUrl from the non-authenticated fetchPlaybackUrl [endpoint](https://github.com/livepeer/player/blob/be5eebb47efdaa997ee4dcce818dc72cbf7ff627/src/index.ts#L42)
- [ ] Restore metrics reporting URL
- [ ] Remove Docs Example page or finalise
- [ ] Update all Docs examples to use the VideoPlayer component
- [ ] Delete the VideoPlayer component inside `docs/components/code/` since not needed anymore